### PR TITLE
Added error message description for dustbin being blocked

### DIFF
--- a/sharkiq/sharkiq.py
+++ b/sharkiq/sharkiq.py
@@ -87,6 +87,7 @@ ERROR_MESSAGES = {
     14: "Magnetic strip error",
     16: "Top bumper is stuck",
     18: "Wheel encoder error",
+    40: "Dustbin is blocked",
 }
 
 


### PR DESCRIPTION
I have a self-empty shark IQ XL vacuum and received error #40 the other day which had an unknown description. The description in the app read "I am unable to empty debris into the dock dust bin. Please empty my dock dust bin and remove blockages."

I have updated the code to add a description for this error.